### PR TITLE
Contain click to parent of custom element

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,18 @@ Add a little spark to your clicks. ✨
 
 ## Usage
 
-Put the custom element before the closing `</body>` tag:
+Add the custom element wherever we want to see sparks fly.
 
 ```html
 <body>
-  <!-- other page elements -->
+  <!-- sparks appear everywhere we click -->
   <click-spark></click-spark>
 </body>
+
+<div class="container">
+  <!-- sparks only appear when clicking inside container -->
+  <click-spark></click-spark>
+</div>
 ```
 
 ## Change spark color
@@ -22,19 +27,3 @@ Set a spark color via CSS custom property:
 ```html
 <click-spark style="--click-spark-color: blue"></click-spark>
 ```
-
-## Set active elements
-
-Want the spark to only occur on particular elements? Pass in a comma-separated list of selectors:
-
-```html
-<click-spark active-on=".send-sparks, #i-love-sparks, [data-sparks]"></click-spark>
-```
-
-Here's a [CodePen demo](https://codepen.io/hexagoncircle/pen/rNReOPd) of that example.
-
-## Dev notes
-
-This is very experimental and created for the joy of the web. More testing should be done before deploying this one to prod.
-
-PRs and feedback always welcome. 🎷

--- a/click-spark.js
+++ b/click-spark.js
@@ -1,24 +1,22 @@
 class ClickSpark extends HTMLElement {
   constructor() {
     super();
-    this.attachShadow({ mode: "open" });
-    this.root = document.documentElement;
     this.svg;
-  }
-
-  get activeEls() {
-    return this.getAttribute("active-on");
+    this.attachShadow({ mode: "open" });
   }
 
   connectedCallback() {
     this.setupSpark();
+    this.parentNode.addEventListener("click", this.handleClick.bind(this));
+  }
 
-    this.root.addEventListener("click", (e) => {
-      if (this.activeEls && !e.target.matches(this.activeEls)) return;
+  detachedCallback() {
+    this.removeEventListener("click", this.handleClick);
+  }
 
-      this.setSparkPosition(e);
-      this.animateSpark();
-    });
+  handleClick(e) {
+    this.setSparkPosition(e);
+    this.animateSpark();
   }
 
   animateSpark() {
@@ -51,19 +49,13 @@ class ClickSpark extends HTMLElement {
   }
 
   setSparkPosition(e) {
-    let rect = this.root.getBoundingClientRect();
-
-    this.svg.style.left = e.clientX - rect.left - this.svg.clientWidth / 2 + "px";
-    this.svg.style.top = e.clientY - rect.top - this.svg.clientHeight / 2 + "px";
+    this.svg.style.left = e.clientX - this.svg.clientWidth / 2 + "px";
+    this.svg.style.top = e.clientY - this.svg.clientHeight / 2 + "px";
   }
 
   setupSpark() {
     let template = `
-      <style>
-        :host {
-          display: contents;
-        }
-        
+      <style>        
         svg {
           pointer-events: none;
           position: absolute;


### PR DESCRIPTION
Previously, I had suggested adding the custom element before the closing `body` tag. There was an `active-on` attribute in which we could set specific DOM elements for the sparks to appear. In retrospect, this was a bit silly. 😅

### Update

- Sets the click event on the parent node.
- Click event is removed from the parent node in `detachedCallback` if the custom element disappears from the DOM.

### Cleanup 🧹 
- Removed the `active-on` attribute as it's no longer necessary.
- The `:host` style ruleset wasn't needed, now removed.