### PR TITLE
Set display contents on host

### DIFF
--- a/click-spark.js
+++ b/click-spark.js
@@ -55,7 +55,10 @@ class ClickSpark extends HTMLElement {
 
   setupSpark() {
     let template = `
-      <style>        
+      <style>
+        :host {
+          display: contents;
+        }
         svg {
           pointer-events: none;
           position: absolute;


### PR DESCRIPTION
This fixes a regression when removing `display: contents` on the custom element. It's preferred that the `click-spark` not affect a container's layout. From [caniuse.com](https://caniuse.com/css-display-contents):

> `display: contents` causes an element's children to appear as if they were direct children of the element's parent, ignoring the element itself. **This can be useful when a wrapper element should be ignored when using CSS grid or similar layout techniques**.)