### PR TITLE
Fix click event listener removal

### DIFF
--- a/click-spark.js
+++ b/click-spark.js
@@ -3,15 +3,16 @@ class ClickSpark extends HTMLElement {
     super();
     this.svg;
     this.attachShadow({ mode: "open" });
+    this.clickEvent = this.handleClick.bind(this);
   }
 
   connectedCallback() {
     this.setupSpark();
-    this.parentNode.addEventListener("click", this.handleClick.bind(this));
+    this.parentNode.addEventListener("click", this.clickEvent);
   }
 
   detachedCallback() {
-    this.removeEventListener("click", this.handleClick);
+    this.removeEventListener("click", this.clickEvent);
   }
 
   handleClick(e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "click-spark",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A web component that adds a little spark to your clicks",
   "main": "click-spark.js",
   "scripts": {},


### PR DESCRIPTION
Properly clean up the parent click event when the custom element is removed from the DOM