### PR TITLE
Fix garbage collection for event listener

### DIFF
--- a/click-spark.js
+++ b/click-spark.js
@@ -1,7 +1,6 @@
 class ClickSpark extends HTMLElement {
   constructor() {
     super();
-    this.svg;
     this.attachShadow({ mode: "open" });
     this.clickEvent = this.handleClick.bind(this);
   }
@@ -11,8 +10,8 @@ class ClickSpark extends HTMLElement {
     this.parentNode.addEventListener("click", this.clickEvent);
   }
 
-  detachedCallback() {
-    this.removeEventListener("click", this.clickEvent);
+  disconnectedCallback() {
+    this.parentNode.removeEventListener("click", this.clickEvent);
   }
 
   handleClick(e) {


### PR DESCRIPTION
Unless I'm mistaken, `detachedCallback` was the [v0](https://web.dev/articles/customelements) name, which is now obsolete and superseded by `disconnectedCallback`?

We also need to remove the event listener from the node it was registered on.